### PR TITLE
Add possibility to configure an animation delay

### DIFF
--- a/Sources/Marquee/Utils.swift
+++ b/Sources/Marquee/Utils.swift
@@ -13,6 +13,10 @@ struct DurationKey: EnvironmentKey {
     static var defaultValue: Double = 2.0
 }
 
+struct DelayKey: EnvironmentKey {
+    static var defaultValue: Double = 3.0
+}
+
 struct AutoreversesKey: EnvironmentKey {
     static var defaultValue: Bool = false
 }
@@ -33,6 +37,11 @@ extension EnvironmentValues {
     var marqueeDuration: Double {
         get {self[DurationKey.self]}
         set {self[DurationKey.self] = newValue}
+    }
+
+    var marqueeDelay: Double {
+        get {self[DelayKey.self]}
+        set {self[DelayKey.self] = newValue}
     }
     
     var marqueeAutoreverses: Bool {
@@ -69,6 +78,11 @@ public extension View {
     /// - Returns: A view that has the given value set in its environment.
     func marqueeDuration(_ duration: Double) -> some View {
         environment(\.marqueeDuration, duration)
+    }
+
+    // TODO: docu
+    func marqueeDelay(_ delay: Double) -> some View {
+        environment(\.marqueeDelay, delay)
     }
     
     /// Sets the marquee animation autoreverses to the given value.

--- a/Sources/Marquee/Utils.swift
+++ b/Sources/Marquee/Utils.swift
@@ -87,7 +87,7 @@ public extension View {
     ///     }.marqueeDelay(5.0)
     ///
     /// - Parameters:
-    ///   - duration: Animation delay, default is `3.0`.
+    ///   - delay: Animation delay, default is `3.0`.
     ///
     /// - Returns: A view that has the given value set in its environment.
     func marqueeDelay(_ delay: Double) -> some View {

--- a/Sources/Marquee/Utils.swift
+++ b/Sources/Marquee/Utils.swift
@@ -80,7 +80,16 @@ public extension View {
         environment(\.marqueeDuration, duration)
     }
 
-    // TODO: docu
+    /// Sets the marquee animation delay to the given value.
+    ///
+    ///     Marquee {
+    ///         Text("Hello World!")
+    ///     }.marqueeDelay(5.0)
+    ///
+    /// - Parameters:
+    ///   - duration: Animation delay, default is `3.0`.
+    ///
+    /// - Returns: A view that has the given value set in its environment.
     func marqueeDelay(_ delay: Double) -> some View {
         environment(\.marqueeDelay, delay)
     }


### PR DESCRIPTION
## Description
### Change
Adding the possibility to configure a delay for the `marquee` animation.  This value is passed to the `Animation.delay(...)` function when starting it.

### Usage Example
```swift
Marquee {
    Text("Hello World!")
}.marqueeDelay(5.0)
```