### PR TITLE
Add marquee boundary configuration

### DIFF
--- a/Sources/Marquee/Marquee.swift
+++ b/Sources/Marquee/Marquee.swift
@@ -12,6 +12,13 @@ public enum MarqueeDirection {
     case left2right
 }
 
+public enum MarqueeBoundary {
+    /// Keeps the content visible and uses the inner boundary for the animation.
+    case inner
+    /// Moves the content outside of the view and uses the outer boundary for the animation.
+    case outer
+}
+
 private enum MarqueeState {
     case idle
     case ready
@@ -24,6 +31,7 @@ public struct Marquee<Content> : View where Content : View {
     @Environment(\.marqueeDirection) var direction: MarqueeDirection
     @Environment(\.marqueeWhenNotFit) var stopWhenNotFit: Bool
     @Environment(\.marqueeIdleAlignment) var idleAlignment: HorizontalAlignment
+    @Environment(\.marqueeBoundary) var boundary: MarqueeBoundary
     
     private var content: () -> Content
     @State private var state: MarqueeState = .idle
@@ -82,9 +90,13 @@ public struct Marquee<Content> : View where Content : View {
                 return 0
             }
         case .ready:
-            return (direction == .right2left) ? 0 : -contentWidth
+            return (direction == .right2left)
+                ? boundary == .outer ? proxy.size.width : 0
+                : -contentWidth
         case .animating:
-            return (direction == .right2left) ? proxy.size.width - contentWidth : proxy.size.width
+            return (direction == .right2left)
+                ? boundary == .outer ? -contentWidth : proxy.size.width - contentWidth
+                : proxy.size.width
         }
     }
     

--- a/Sources/Marquee/Marquee.swift
+++ b/Sources/Marquee/Marquee.swift
@@ -82,9 +82,9 @@ public struct Marquee<Content> : View where Content : View {
                 return 0
             }
         case .ready:
-            return (direction == .right2left) ? proxy.size.width : -contentWidth
+            return (direction == .right2left) ? 0 : -contentWidth
         case .animating:
-            return (direction == .right2left) ? -contentWidth : proxy.size.width
+            return (direction == .right2left) ? proxy.size.width - contentWidth : proxy.size.width
         }
     }
     

--- a/Sources/Marquee/Utils.swift
+++ b/Sources/Marquee/Utils.swift
@@ -29,6 +29,10 @@ struct AlignmentKey: EnvironmentKey {
     static var defaultValue: HorizontalAlignment = .leading
 }
 
+struct BoundaryKey: EnvironmentKey {
+    static var defaultValue: MarqueeBoundary = .outer
+}
+
 extension EnvironmentValues {
     var marqueeDuration: Double {
         get {self[DurationKey.self]}
@@ -53,6 +57,11 @@ extension EnvironmentValues {
     var marqueeIdleAlignment: HorizontalAlignment {
         get {self[AlignmentKey.self]}
         set {self[AlignmentKey.self] = newValue}
+    }
+
+    var marqueeBoundary: MarqueeBoundary {
+        get {self[BoundaryKey.self]}
+        set {self[BoundaryKey.self] = newValue}
     }
 }
 
@@ -125,6 +134,20 @@ public extension View {
     /// - Returns: A view that has the given value set in its environment.
     func marqueeIdleAlignment(_ alignment: HorizontalAlignment) -> some View {
         environment(\.marqueeIdleAlignment, alignment)
+    }
+
+    /// Sets the marquee boundaries to the given value
+    ///
+    ///     Marquee {
+    ///         Text("Hello World!")
+    ///     }.marqueeBoundary(.inner)
+    ///
+    /// - Parameters:
+    ///   - boundary: Boundary when the animation will be finished. See `MarqueeBoundary` for possible values, default is `.outer`.
+    ///
+    /// - Returns: A view that has the given value set in its environment.
+    func marqueeBoundary(_ boundary: MarqueeBoundary) -> some View {
+        environment(\.marqueeBoundary, boundary)
     }
 }
 


### PR DESCRIPTION
## Description

### Changes
Added the possibility to configure the boundary which will be used for the marquee animation.

- `MarqueeBoundary.outer` will start the animation with the content (e.g. `Text`) not visible and starts the animation with the container empty. (as before - `default`)
- `MarqueeBoundary.inner` will keep the content (e.g. `Text`) visible and starts the animation with the container filled.

### Usage Example
```swift
    Marquee {
        Text("Hello World!")
    }.marqueeBoundary(.inner)
```

_thx to @dillonhafer for inspiration_