### PR TITLE
fix(#10): resetAnimation on size change

### DIFF
--- a/Sources/Marquee/Marquee.swift
+++ b/Sources/Marquee/Marquee.swift
@@ -67,6 +67,9 @@ public struct Marquee<Content> : View where Content : View {
             .onChange(of: direction) { [] _ in
                 resetAnimation(duration: duration, autoreverses: autoreverses, proxy: proxy)
             }
+            .onChange(of: proxy.size) { [] _ in
+                resetAnimation(duration: duration, autoreverses: autoreverses, proxy: proxy)
+            }
         }.clipped()
     }
     


### PR DESCRIPTION
In this PR, I added a onChange for proxy.size to detect any size changes and update the animation state.